### PR TITLE
Migrate paho 2.0

### DIFF
--- a/tedge_modbus/reader/reader.py
+++ b/tedge_modbus/reader/reader.py
@@ -374,7 +374,7 @@ class ModbusPoll:
                 broker = self.base_config["thinedge"]["mqtthost"]
                 port = self.base_config["thinedge"]["mqttport"]
                 client_id = "modbus-client"
-                client = mqtt_client.Client(client_id)
+                client = mqtt_client.Client(mqtt_client.CallbackAPIVersion.VERSION1,client_id)
                 client.connect(broker, port)
                 self.logger.debug("Connected to MQTTT broker at %s:%d", broker, port)
                 return client


### PR DESCRIPTION
mqtt_client.CallbackAPIVersion.VERSION1 parameter to client creation.