### PR TITLE
feat: update tedge dependency to at least 1.2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
-#DEB PACKAGES
+#Linux PACKAGES
 *.deb
+*.rpm
+dist/
 
 #Test files
 /output

--- a/justfile
+++ b/justfile
@@ -26,6 +26,12 @@ lint:
     .venv/bin/python3 -m pylint operations
     .venv/bin/python3 -m pylint tedge_modbus
 
+# Build linux packages
+build:
+    mkdir -p dist/
+    nfpm package --packager deb --target dist/
+    nfpm package --packager rpm --target dist/
+
 # Build deb package
 setup:
     @mkdir -p ./tests/data

--- a/nfpm.yaml
+++ b/nfpm.yaml
@@ -58,6 +58,7 @@ contents:
 overrides:
   deb:
     depends:
+      - tedge (>= 1.2.0)
       - python (>= 3.8.0) | python3 (>= 3.8.0)
       - python3-paho-mqtt
       - python3-pymodbus
@@ -72,6 +73,7 @@ overrides:
       postremove: ./scripts/deb/postrm
   rpm:
     depends:
+      - tedge >= 1.2.0
       - python3
       - python3-paho-mqtt
       - python3-pymodbus

--- a/scripts/deb/postinst
+++ b/scripts/deb/postinst
@@ -1,45 +1,8 @@
 #!/bin/sh
 set -e
 
-add_smartrest_template() {
-        # Add a new Cumulocity IoT SmartRest template to the thin-edge.io settings
-        template_name="$1"
-        EXISTING_TEMPLATES=$(tedge config get c8y.smartrest.templates | tr -d '\\[]" ')
-        UPDATED_TEMPLATES=
-
-        if [ -z "$template_name" ]; then
-                echo "Invalid template name given. Template name must not be empty." >&2
-                return 1
-        fi
-
-        EXISTS=0
-        if [ -n "$EXISTING_TEMPLATES" ]; then
-                for value in $(echo "$EXISTING_TEMPLATES" | tr ',' '\n '); do
-                        if [ "$value" = "$template_name" ]; then
-                                EXISTS=1
-                                break
-                        fi
-                done
-        fi
-        
-        if [ "$EXISTS" -eq 1 ]; then
-                echo "c8y.smartrest.template has already been added. name=$template_name" >&2
-                return
-        fi
-
-        if [ -n "$EXISTING_TEMPLATES" ]; then
-                UPDATED_TEMPLATES="${EXISTING_TEMPLATES},$template_name"
-        else
-                UPDATED_TEMPLATES="$template_name"
-        fi
-
-        if [ -n "$UPDATED_TEMPLATES" ]; then
-                tedge config set c8y.smartrest.templates "$UPDATED_TEMPLATES"
-                tedge refresh-bridges
-        fi
-}
-
-add_smartrest_template modbus
+tedge config add c8y.smartrest.templates modbus
+tedge refresh-bridges
 
 # Automatically added by thin-edge.io
 if [ "$1" = "configure" ] || [ "$1" = "abort-upgrade" ] || [ "$1" = "abort-deconfigure" ] || [ "$1" = "abort-remove" ] ; then

--- a/scripts/deb/postrm
+++ b/scripts/deb/postrm
@@ -20,44 +20,7 @@ if [ "$1" = "purge" ]; then
 fi
 # End automatically added section
 
-remove_smartrest_template() {
-        # Add a new Cumulocity IoT SmartRest template to the thin-edge.io settings
-        template_name="$1"
-        EXISTING_TEMPLATES=$(tedge config get c8y.smartrest.templates | tr -d '\\[]" ')
-        UPDATED_TEMPLATES=
-
-        if [ -z "$template_name" ]; then
-                echo "Invalid template name given. Template name must not be empty." >&2
-                return 1
-        fi
-
-        UPDATE_TEMPLATES=
-        if [ -n "$EXISTING_TEMPLATES" ]; then
-                for value in $(echo "$EXISTING_TEMPLATES" | tr ',' '\n '); do
-                        if [ "$value" != "$template_name" ]; then
-                                if [ -n "$UPDATE_TEMPLATES" ]; then
-                                    UPDATE_TEMPLATES="${UPDATE_TEMPLATES},${value}"
-                                else
-                                    UPDATE_TEMPLATES="${value}"
-                                fi
-                        fi
-                done
-        fi
-
-        if [ "$UPDATE_TEMPLATES" = "$EXISTING_TEMPLATES" ]; then
-            echo "c8y.smartrest.template does not contain the template. name=$template_name" >&2
-            return
-        fi
-    
-        echo "Removing c8y.smartrest.template. name=$template_name" >&2
-        if [ -n "$UPDATED_TEMPLATES" ]; then
-            tedge config set c8y.smartrest.templates "$UPDATED_TEMPLATES"
-        else
-            tedge config unset c8y.smartrest.templates
-        fi
-        tedge refresh-bridges
-}
-
 if [ "$1" = "remove" ]; then
-    remove_smartrest_template modbus
+    tedge config remove c8y.smartrest.templates modbus
+	tedge refresh-bridges
 fi

--- a/scripts/rpm/postinst
+++ b/scripts/rpm/postinst
@@ -1,45 +1,8 @@
 #!/bin/sh
 set -e
 
-add_smartrest_template() {
-        # Add a new Cumulocity IoT SmartRest template to the thin-edge.io settings
-        template_name="$1"
-        EXISTING_TEMPLATES=$(tedge config get c8y.smartrest.templates | tr -d '\\[]" ')
-        UPDATED_TEMPLATES=
-
-        if [ -z "$template_name" ]; then
-                echo "Invalid template name given. Template name must not be empty." >&2
-                return 1
-        fi
-
-        EXISTS=0
-        if [ -n "$EXISTING_TEMPLATES" ]; then
-                for value in $(echo "$EXISTING_TEMPLATES" | tr ',' '\n '); do
-                        if [ "$value" = "$template_name" ]; then
-                                EXISTS=1
-                                break
-                        fi
-                done
-        fi
-        
-        if [ "$EXISTS" -eq 1 ]; then
-                echo "c8y.smartrest.template has already been added. name=$template_name" >&2
-                return
-        fi
-
-        if [ -n "$EXISTING_TEMPLATES" ]; then
-                UPDATED_TEMPLATES="${EXISTING_TEMPLATES},$template_name"
-        else
-                UPDATED_TEMPLATES="$template_name"
-        fi
-
-        if [ -n "$UPDATED_TEMPLATES" ]; then
-                tedge config set c8y.smartrest.templates "$UPDATED_TEMPLATES"
-                tedge refresh-bridges
-        fi
-}
-
-add_smartrest_template modbus
+tedge config add c8y.smartrest.templates modbus
+tedge refresh-bridges
 
 # Automatically added by thin-edge.io
 if [ $1 -eq 1 ] && [ -x "/usr/lib/systemd/systemd-update-helper" ]; then

--- a/scripts/rpm/postrm
+++ b/scripts/rpm/postrm
@@ -13,44 +13,7 @@ fi
 
 # End automatically added section
 
-remove_smartrest_template() {
-        # Add a new Cumulocity IoT SmartRest template to the thin-edge.io settings
-        template_name="$1"
-        EXISTING_TEMPLATES=$(tedge config get c8y.smartrest.templates | tr -d '\\[]" ')
-        UPDATED_TEMPLATES=
-
-        if [ -z "$template_name" ]; then
-                echo "Invalid template name given. Template name must not be empty." >&2
-                return 1
-        fi
-
-        UPDATE_TEMPLATES=
-        if [ -n "$EXISTING_TEMPLATES" ]; then
-                for value in $(echo "$EXISTING_TEMPLATES" | tr ',' '\n '); do
-                        if [ "$value" != "$template_name" ]; then
-                                if [ -n "$UPDATE_TEMPLATES" ]; then
-                                    UPDATE_TEMPLATES="${UPDATE_TEMPLATES},${value}"
-                                else
-                                    UPDATE_TEMPLATES="${value}"
-                                fi
-                        fi
-                done
-        fi
-
-        if [ "$UPDATE_TEMPLATES" = "$EXISTING_TEMPLATES" ]; then
-            echo "c8y.smartrest.template does not contain the template. name=$template_name" >&2
-            return
-        fi
-    
-        echo "Removing c8y.smartrest.template. name=$template_name" >&2
-        if [ -n "$UPDATED_TEMPLATES" ]; then
-            tedge config set c8y.smartrest.templates "$UPDATED_TEMPLATES"
-        else
-            tedge config unset c8y.smartrest.templates
-        fi
-        tedge refresh-bridges
-}
-
 if [ "$1" = "0" ]; then
-    remove_smartrest_template modbus
+    tedge config remove c8y.smartrest.templates modbus
+    tedge refresh-bridges
 fi


### PR DESCRIPTION
Update thin-edge.io dependency to allow usage of the newer `tedge config add/remove` command to simplify the package maintainer scripts