### PR TITLE
chore: update pip dependencies for local development only

### DIFF
--- a/images/simulator/requirements.txt
+++ b/images/simulator/requirements.txt
@@ -1,2 +1,2 @@
-aiohttp==3.9.2
+aiohttp~=3.10.2
 pymodbus==3.5.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,5 @@ pyModbusTCP
 pyserial-asyncio
 tomli~=2.0.1
 pip~=23.3
-setuptools~=65.5.0
-requests~=2.31.0
+requests~=2.32.0
 toml

--- a/tests/modbus_reader/device.robot
+++ b/tests/modbus_reader/device.robot
@@ -8,7 +8,7 @@ Suite Setup     Set Main Device
 *** Test Cases ***
 Device should have the fragment c8y_ModbusConfiguration
     Cumulocity.Managed Object Should Have Fragments    c8y_ModbusConfiguration
-    Cumulocity.Managed Object Should Have Fragment Values    c8y_ModbusConfiguration.pollingRate=2
+    Cumulocity.Managed Object Should Have Fragment Values    c8y_ModbusConfiguration.pollingRate\=2
 
 ChildDevice TestCase1 should be created
     Cumulocity.Should Be A Child Device Of Device    ${DEVICE_ID}:device:TestCase1

--- a/tests/modbus_reader/device.robot
+++ b/tests/modbus_reader/device.robot
@@ -8,7 +8,7 @@ Suite Setup     Set Main Device
 *** Test Cases ***
 Device should have the fragment c8y_ModbusConfiguration
     Cumulocity.Managed Object Should Have Fragments    c8y_ModbusConfiguration
-    Cumulocity.Managed Object Should Have Fragment Values    c8y_ModbusConfiguration.pollingRate\=2
+    Cumulocity.Managed Object Should Have Fragment Values    c8y_ModbusConfiguration.pollingRate\=3
 
 ChildDevice TestCase1 should be created
     Cumulocity.Should Be A Child Device Of Device    ${DEVICE_ID}:device:TestCase1

--- a/tests/modbus_reader/device.robot
+++ b/tests/modbus_reader/device.robot
@@ -7,8 +7,8 @@ Suite Setup     Set Main Device
 
 *** Test Cases ***
 Device should have the fragment c8y_ModbusConfiguration
-    Cumulocity.Device Should Have Fragments    c8y_ModbusConfiguration
-    Managed Object Should Have Fragment Values    c8y_ModbusConfiguration.pollingRate=2
+    Cumulocity.Managed Object Should Have Fragments    c8y_ModbusConfiguration
+    Cumulocity.Managed Object Should Have Fragment Values    c8y_ModbusConfiguration.pollingRate=2
 
 ChildDevice TestCase1 should be created
     Cumulocity.Should Be A Child Device Of Device    ${DEVICE_ID}:device:TestCase1

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,2 +1,2 @@
-robotframework~=6.0.0
-robotframework-c8y @ git+https://github.com/reubenmiller/robotframework-c8y.git@0.31.3
+robotframework~=7.0.0
+robotframework-c8y @ git+https://github.com/reubenmiller/robotframework-c8y.git@0.42.1


### PR DESCRIPTION
Update the python requirements.txt files. These files are only used when installing the project manually via a `git clone` etc. This does not affect the dependencies as defined in the linux packaging.