### PR TITLE
ci: update runner images to ubuntu-22.04

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
     name: Build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
     needs: [approve]
     environment:
       name: Test Auto
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       COMPOSE_PROJECT_NAME: ci_${{github.run_id}}_${{github.run_attempt || '1'}}
       DEVICE_ID: ci_${{github.run_id}}_${{github.run_attempt || '1'}}


### PR DESCRIPTION
Update deprecated ubuntu-20.04 images to ubuntu-22.04 as Github no longer supports the former.