### PR TITLE
Feat/efficiency enhancements: Implement per-device polling and on-change publishing

### DIFF
--- a/tedge_modbus/reader/reader.py
+++ b/tedge_modbus/reader/reader.py
@@ -258,8 +258,9 @@ class ModbusPoll:
         else:
             self.logger.error("Failed to poll device %s: %s", device["name"], error)
 
+        interval = device.get("poll_interval", self.base_config["modbus"]["pollinterval"])
         self.poll_scheduler.enter(
-            self.base_config["modbus"]["pollinterval"],
+            interval,
             1,
             self.poll_device,
             (device, poll_model, mapper),


### PR DESCRIPTION
### **Pull Request Description:**

This pull request introduces two key efficiency enhancements to the Modbus plugin, designed to reduce unnecessary data traffic and allow for more flexible polling strategies.These changes enable users to prioritize high-frequency data from critical devices while minimizing network and cloud resource usage for static or infrequently changing data points.

### Motivation

In many industrial environments, it's necessary to monitor certain devices (like critical sensors) at a high frequency (e.g., every second), while other devices only require infrequent updates. Similarly, some registers, such as status flags, only need to be reported when their value changes. This implementation addresses that need by providing more granular control over data polling and publishing.

### Features Implemented

**1. Per-Device Polling Interval**

This feature allows a custom polling interval to be set for each individual Modbus device, overriding the global default.

* **How it Works:** The plugin checks for an optional `poll_interval` key within a device's configuration in the `devices.toml` file. If this key is present, its value is used for that specific device. If it is absent, the plugin falls back to the global `pollinterval` defined in `modbus.toml`, ensuring full backward compatibility.
* **Configuration:** To set a custom rate, add `poll_interval = <seconds>` to a `[[device]]` table in `devices.toml`.

**2. On-Change Publishing**

This feature prevents the plugin from publishing data for a register if its value has not changed since the last poll.

* **How it Works:** For any register configured with `on_change = true`, the plugin caches the last published value. A new MQTT message is only published if the newly polled value is different from the cached one, or on the very first poll for that register. If the `on_change` key is false or absent, the default behavior of publishing after every poll is maintained.
* **Configuration:** To enable this, add `on_change = true` to a `[[device.registers]]` table in `devices.toml`.

### Example Configurations
 **Test `modbus.toml`:**

```toml
[modbus]
ip_address = "127.0.0.1"
port = 502
pollinterval = 5
loglevel = "INFO"

[thinedge]
mqtthost= "127.0.0.1"
mqttport = 1883
```

**Test  `devices.toml` with new updates:**

```toml
[[device]]
name = "mock_battery"
address = 1
ip = "127.0.0.1"
port = 502
protocol = "TCP"
poll_interval = 1  # new update
[[device.registers]]
number = 0
startbit = 0
nobits = 16
signed = false
multiplier = 1
input = false
measurementmapping.templatestring = '{"power": %%}'

[[device.registers]]
number = 100
startbit = 0
nobits = 16
signed = false
input = false
measurementmapping.templatestring = '{"error_flag": %%}'
on_change = true # new update
```
