### PR TITLE
chore: bump aiohttp version to 3.12.14

### DIFF
--- a/images/simulator/requirements.txt
+++ b/images/simulator/requirements.txt
@@ -1,2 +1,2 @@
-aiohttp~=3.10.2
+aiohttp~=3.12.14
 pymodbus==3.5.4


### PR DESCRIPTION
Resolves https://github.com/thin-edge/modbus-plugin/security/dependabot/12