### PR TITLE
Feat complex / combine measurements

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,10 +88,11 @@ This includes the basic configuration for the plugin such as poll rate and the c
 - poll rate
 - connection to thin-edge.io (MQTT broker needs to match the one of tedge)
 - log level (e.g. INFO, WARN, ERROR)
+- measurement combination (opt-in feature to reduce the amount of created measurements in the cloud)
 
 ### devices.toml
 
-This file includes the information for the connection(s) to the Modbus server(s) and how the Modbus Registers and Coils map to thin-edge’s Measurements, Events and Alarms.
+This file includes the information for the connection(s) to the Modbus server(s) and how the Modbus Registers and Coils map to thin-edge’s Measurements, Events and Alarms. It's also possible to overwrite the measurement combination on a device level.
 
 The device config can be managed via Cumulocity IoT or created with the Cloud Fieldbus operations.
 

--- a/config/devices.toml
+++ b/config/devices.toml
@@ -7,6 +7,7 @@ port=502 # Modbus server Port
 protocol="TCP" # only support for TCP now
 littlewordendian=false
 #pollinterval=1  # Overrides global setting; device publishes at this interval
+#combinemeasurements=true # Overrides global setting; Combines all measurements of a device to reduce the number of created measurements in the cloud
 
 
 [[device.registers]]

--- a/config/modbus.toml
+++ b/config/modbus.toml
@@ -1,6 +1,7 @@
 [modbus]
 pollinterval=2
 loglevel="INFO"
+#combinemeasurements=true # if not set equals false; combines all measurements of a device to reduce the number of created measurements in the cloud
 
 [thinedge]
 mqtthost="127.0.0.1"

--- a/tedge_modbus/reader/mapper.py
+++ b/tedge_modbus/reader/mapper.py
@@ -21,6 +21,28 @@ class MappedMessage:
     data: str = ""
     topic: str = ""
 
+    def extend_data(self, other_message):
+        """Combine Json data of two messages with the same topic"""
+        if self.topic != other_message.topic:
+            raise ValueError("Messages need to have the same topic")
+
+        def merge(d1: dict, d2: dict) -> dict:
+            """Recursively merge two dictionaries."""
+            for k, v in d2.items():
+                if k in d1 and isinstance(d1[k], dict) and isinstance(v, dict):
+                    d1[k] = merge(d1[k], v)
+                else:
+                    d1[k] = v
+            return d1
+
+        # Load both JSON strings into dictionaries
+        d1 = json.loads(self.data)
+        d2 = json.loads(other_message.data)
+        # Merge the dictionaries
+        merged = merge(d1, d2)
+        # Convert the merged dictionary back to a JSON string and update self.data
+        self.data = json.dumps(merged)
+
 
 class ModbusMapper:
     """Modbus mapper"""
@@ -60,10 +82,11 @@ class ModbusMapper:
             formats[field_len], buffer.to_bytes(int(field_len / 8), sys.byteorder)
         )[0]
 
-    def map_register(self, read_register, register_def):
+    def map_register(self, read_register, register_def, separate_measurement=False):
         """Map register"""
         # pylint: disable=too-many-locals
         messages = []
+        measurement = None
         start_bit = register_def["startbit"]
         field_len = register_def["nobits"]
         is_little_endian = register_def.get("littleendian") or False
@@ -119,15 +142,10 @@ class ModbusMapper:
                 data = register_def["measurementmapping"]["templatestring"].replace(
                     "%%", str(scaled_value)
                 )
-                messages.append(
-                    MappedMessage(
-                        data,
-                        topics["measurement"].replace(
-                            "CHILD_ID", self.device.get("name")
-                        ),
-                    )
+                measurement = MappedMessage(
+                    data,
+                    topics["measurement"].replace("CHILD_ID", self.device.get("name")),
                 )
-                self.data.setdefault(register_type, {})[register_key] = scaled_value
 
             value = scaled_value
         if register_def.get("alarmmapping") is not None:
@@ -143,8 +161,12 @@ class ModbusMapper:
                 )
             )
 
-        if register_def.get("measurementmapping") is None:
-            self.data.setdefault(register_type, {})[register_key] = value
+        self.data.setdefault(register_type, {})[register_key] = value
+
+        if separate_measurement:
+            return messages, measurement
+        if measurement is not None:
+            messages.append(measurement)
         return messages
 
     def map_coil(self, bits, coil_definition):

--- a/tedge_modbus/reader/reader.py
+++ b/tedge_modbus/reader/reader.py
@@ -206,6 +206,11 @@ class ModbusPoll:
             ir_result,
             error,
         ) = self.get_data_from_device(device, poll_model)
+        combine_measurements = device.get(
+            "combinemeasurements",
+            self.base_config["modbus"].get("combinemeasurements", False),
+        )
+        combined_measuerement = None
         if error is None:
             # handle all Registers
             if device.get("registers") is not None:
@@ -231,11 +236,27 @@ class ModbusPoll:
                             result = self.read_register(
                                 hr_results, address=register_number, count=num_registers
                             )
-                        msgs = mapper.map_register(result, register_definition)
+                        if combine_measurements:
+                            msgs, temp = mapper.map_register(
+                                result, register_definition, combine_measurements
+                            )
+                            if combined_measuerement is not None:
+                                combined_measuerement.extend_data(temp)
+                            else:
+                                combined_measuerement = temp
+                        else:
+                            msgs = mapper.map_register(result, register_definition)
                         for msg in msgs:
                             self.send_tedge_message(msg)
                     except Exception as e:
                         self.logger.error("Failed to map register: %s", e)
+
+            # send combined measurement if any
+            try:
+                if combined_measuerement is not None:
+                    self.send_tedge_message(combined_measuerement)
+            except Exception as e:
+                self.logger.error("Failed to send combined measurement: %s", e)
 
             # all Coils
             if device.get("coils") is not None:

--- a/tests/unit/test_reader.py
+++ b/tests/unit/test_reader.py
@@ -24,16 +24,16 @@ class TestReaderPollingInterval(unittest.TestCase):
 
     def test_uses_device_specific_poll_interval(self):
         """
-        GIVEN a device has a specific poll_interval
+        GIVEN a device has a specific pollinterval
         WHEN the poller schedules the next poll for that device
         THEN it should use the device's interval.
         """
         # GIVEN a global poll interval
         self.poll.base_config = {"modbus": {"pollinterval": 5}}
-        # AND a device with its own poll_interval
+        # AND a device with its own pollinterval
         device_config = {
             "name": "fast_poller",
-            "poll_interval": 1,  # This should be used
+            "pollinterval": 1,  # This should be used
         }
 
         mock_poll_model = MagicMock()
@@ -80,3 +80,13 @@ class TestReaderPollingInterval(unittest.TestCase):
         self.poll.poll_scheduler.enter.assert_called_once()
         call_args, _ = self.poll.poll_scheduler.enter.call_args
         self.assertEqual(call_args[0], 5)
+
+    # Todo: Implement the following tests
+    def test_defaults_to_no_measurement_combination(self):
+        pass
+
+    def test_global_measurement_combination(self):
+        pass
+
+    def test_device_specific_measurement_combination(self):
+        pass


### PR DESCRIPTION
### Pull Request Description:
This pull request introduces the creation of [complex / combined Measurements](https://thin-edge.github.io/thin-edge.io/start/send-measurements/#complex-measurements) to the Modbus plugin, designed to reduce unnecessary data traffic to the cloud. These changes enable users to prioritize high-volume data cloud resource usage for static or infrequently changing data points. This Feature works hand in hand with the `on-change` keyword to ensure sending fewer measurements with only the needed data.

### Motivation
I use thin-edge with my own modbus poller and complex / combined measurements for some time now and want to switch to the official plugin. 

### Features Implemented
The feature generally opt-in, devices who currently use this plugin won't change their behavior. It can be activated on a global level as well as on a per device level, opt-out is also possible per Device.

**How it Works:** The plugin checks for an optional `combinemeasuerments` key within the modbus configuration or a device's configuration in the modbus.toml / devices.toml file. When generating the measurements this Key is checked in the Priority 1st Device | 2nd Global . If it is absent in the device, the plugin falls back to the global and if it is absent there it's off, ensuring full backward compatibility.

### Example Configurations
**Test `modbus.toml` with feature active:**

```
[modbus]
pollinterval = 5
loglevel = "INFO"
combinemeasurements=true # if not set equals false; 

[thinedge]
mqtthost= "127.0.0.1"
mqttport = 1883
```
**Test `devices.toml` can still be used to opt-out single devices:**

```
[[device]]
name = "mock_battery1"
address = 1
ip = "127.0.0.1"
port = 502
protocol = "TCP"
combinemeasurements=false # Overrides global setting;

[[device.registers]]
number = 0
startbit = 0
nobits = 16
signed = false
multiplier = 1
input = false
measurementmapping.templatestring = '{"power": %%}'

[[device.registers]]
number = 100
startbit = 0
nobits = 16
signed = false
input = false
measurementmapping.templatestring = '{"error_flag": %%}'
on_change = true # new update

[[device]]
name = "mock_battery_2"
address = 1
ip = "127.0.0.1"
port = 41502
protocol = "TCP"
#combinemeasurements=false # No Override uses the global option

[[device.registers]]
number = 0
startbit = 0
nobits = 16
signed = false
multiplier = 1
input = false
measurementmapping.templatestring = '{"power": %%}'
```