### PR TITLE
ci: add explicit workflow permissions to jobs

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -6,6 +6,9 @@ on:
       - main
   merge_group:
 
+permissions:
+  contents: read
+
 jobs:
   format:
     name: Format

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,8 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-22.04
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,10 @@ on:
   pull_request_target:
     branches: [ main ]
   merge_group:
+
+permissions:
+  contents: read
+
 jobs:
   approve:
     # Note: Use approval as a job so that the downstream jobs are only prompted once (if more than 1 matrix job is defined)
@@ -28,6 +32,11 @@ jobs:
     environment:
       name: Test Auto
     runs-on: ubuntu-22.04
+    permissions:
+      # Required to publish system test results to the PR
+      issues: write
+      pull-requests: write
+      contents: read
     env:
       COMPOSE_PROJECT_NAME: ci_${{github.run_id}}_${{github.run_attempt || '1'}}
       DEVICE_ID: ci_${{github.run_id}}_${{github.run_attempt || '1'}}


### PR DESCRIPTION
Set explicit workflow permissions on jobs according to the security best-practices.