### PR TITLE
chore: update pip dev dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,5 @@ watchdog~=2.1.9
 pyModbusTCP
 pyserial-asyncio
 tomli~=2.0.1
-pip~=23.3
 requests~=2.32.0
 toml


### PR DESCRIPTION
Update the pip dependency due to a security notification, https://github.com/thin-edge/modbus-plugin/security/dependabot/13, and declare it as a dev dependency.