### PR TITLE
Add a function to support set timestamp in the payload

### DIFF
--- a/config/devices.toml
+++ b/config/devices.toml
@@ -35,6 +35,8 @@ decimalshiftright=0
 input=false
 datatype="float"
 measurementmapping.templatestring="{\"Test\":{\"Float32\":%% }}"
+#timestamp and time are also supported in the template 
+#measurementmapping.templatestring="{\"Test\":{\"Float32\":%% }, \"timestamp\":\"\"}"
 
 
 [[device.coils]]


### PR DESCRIPTION
Added a function _process_template in mapper.py. When the template includes 'timestamp' and/or 'time', the mapper.py can set them in ISO format. 