### PR TITLE
Fix main device type and name updates

### DIFF
--- a/tedge_modbus/reader/reader.py
+++ b/tedge_modbus/reader/reader.py
@@ -622,16 +622,19 @@ class ModbusPoll:
     def register_child_devices(self, devices):
         """Register the child devices with thin-edge.io"""
         for device in devices:
-            self.logger.debug("Child device registration for device %s", device["name"])
-            topic = f"te/device/{device['name']}//"
-            payload = {
-                "@type": "child-device",
-                "name": device["name"],
-                "type": "modbus-device",
-            }
-            self.send_tedge_message(
-                MappedMessage(json.dumps(payload), topic), retain=True, qos=1
-            )
+            if device["name"] != "main":
+                self.logger.debug(
+                    "Child device registration for device %s", device["name"]
+                )
+                topic = f"te/device/{device['name']}//"
+                payload = {
+                    "@type": "child-device",
+                    "name": device["name"],
+                    "type": "modbus-device",
+                }
+                self.send_tedge_message(
+                    MappedMessage(json.dumps(payload), topic), retain=True, qos=1
+                )
             cmd_payload = "{}"
             for cmd in ["modbus_SetRegister", "modbus_SetCoil"]:
                 cmd_topic = topic + f"/cmd/{cmd}"

--- a/tedge_modbus/reader/reader.py
+++ b/tedge_modbus/reader/reader.py
@@ -622,11 +622,11 @@ class ModbusPoll:
     def register_child_devices(self, devices):
         """Register the child devices with thin-edge.io"""
         for device in devices:
+            topic = f"te/device/{device['name']}//"
             if device["name"] != "main":
                 self.logger.debug(
                     "Child device registration for device %s", device["name"]
                 )
-                topic = f"te/device/{device['name']}//"
                 payload = {
                     "@type": "child-device",
                     "name": device["name"],
@@ -635,6 +635,8 @@ class ModbusPoll:
                 self.send_tedge_message(
                     MappedMessage(json.dumps(payload), topic), retain=True, qos=1
                 )
+
+            self.logger.debug("Set command registration for device %s", device["name"])
             cmd_payload = "{}"
             for cmd in ["modbus_SetRegister", "modbus_SetCoil"]:
                 cmd_topic = topic + f"/cmd/{cmd}"


### PR DESCRIPTION
## Problem

When `device.name = "main"` is set in `devices.toml`, the plugin attempts to update the name and type of the main device. This results in an error:

```
[te/device/main//] {"@type": "child-device", "name": "main", "type": "modbus-device", "time": "2026-03-19T08:53:51.876779+00:00"}
[te/errors] Updating the entity type of device/main// is not supported
[te/device/main///twin/name] "main"
[te/device/main///twin/time] "2026-03-19T08:53:51.876779+00:00"
[te/device/main///twin/type] "modbus-device"
```

## Expected Behavior

No changes should be applied to the device name or type when referring to the main device.

## Solution

Skip creating a child device when the device name is `main`.
