### PR TITLE
fix(packaging): ignore tedge refresh-bridges at runtime

### DIFF
--- a/scripts/deb/postinst
+++ b/scripts/deb/postinst
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 
-tedge refresh-bridges
+tedge refresh-bridges ||:
 
 # Automatically added by thin-edge.io
 if [ "$1" = "configure" ] || [ "$1" = "abort-upgrade" ] || [ "$1" = "abort-deconfigure" ] || [ "$1" = "abort-remove" ] ; then

--- a/scripts/deb/postrm
+++ b/scripts/deb/postrm
@@ -22,5 +22,5 @@ fi
 
 if [ "$1" = "remove" ]; then
     tedge config remove c8y.smartrest.templates modbus
-	tedge refresh-bridges
+	tedge refresh-bridges ||:
 fi

--- a/scripts/rpm/postinst
+++ b/scripts/rpm/postinst
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 
-tedge refresh-bridges
+tedge refresh-bridges ||:
 
 # Automatically added by thin-edge.io
 if [ $1 -eq 1 ] && [ -x "/usr/lib/systemd/systemd-update-helper" ]; then

--- a/scripts/rpm/postrm
+++ b/scripts/rpm/postrm
@@ -15,5 +15,5 @@ fi
 
 if [ "$1" = "0" ]; then
     tedge config remove c8y.smartrest.templates modbus
-    tedge refresh-bridges
+    tedge refresh-bridges ||:
 fi


### PR DESCRIPTION
It can fail if the service manager is not active which is the case when running under docker at build time.